### PR TITLE
Implement chain response aggregator for server mode

### DIFF
--- a/src/mcp_agent/server/response_aggregator.py
+++ b/src/mcp_agent/server/response_aggregator.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict
+
+
+class ChainResponseAggregator:
+    """Aggregate responses for a multi-agent chain."""
+
+    def __init__(self, chain_name: str, total_agents: int) -> None:
+        self.chain_name = chain_name
+        self.total_agents = total_agents
+        self.agent_responses: Dict[str, Any] = {}
+        self.completed_agents = 0
+        self._response_sent = False
+
+    async def add_agent_response(self, agent_name: str, response: Any) -> None:
+        """Record a response from an agent in the chain."""
+        self.agent_responses[agent_name] = response
+        self.completed_agents += 1
+
+    async def should_send_response(self) -> bool:
+        """Return ``True`` if the aggregated response should be sent."""
+        return not self._response_sent and self.completed_agents >= self.total_agents
+
+    async def get_aggregated_response(self) -> Dict[str, Any]:
+        """Return the aggregated response for the chain."""
+        self._response_sent = True
+        return {"chain": self.chain_name, "responses": self.agent_responses}
+
+
+class SSEEventType(Enum):
+    AGENT_START = "agent_start"
+    AGENT_PROGRESS = "agent_progress"
+    AGENT_COMPLETE = "agent_complete"
+    CHAIN_COMPLETE = "chain_complete"
+    ERROR = "error"
+
+
+async def send_sse_event(event_type: SSEEventType, data: Dict[str, Any], stream: Any) -> None:
+    """Send an SSE event to the provided stream if possible."""
+    if stream is not None and hasattr(stream, "send"):
+        await stream.send({"event": event_type.value, "data": data})

--- a/tests/unit/mcp_agent/server/test_response_aggregator.py
+++ b/tests/unit/mcp_agent/server/test_response_aggregator.py
@@ -1,0 +1,43 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[4] / "src" / "mcp_agent" / "server" / "response_aggregator.py"
+)
+spec = importlib.util.spec_from_file_location("response_aggregator", MODULE_PATH)
+response_aggregator = importlib.util.module_from_spec(spec)
+assert spec.loader
+spec.loader.exec_module(response_aggregator)
+
+ChainResponseAggregator = response_aggregator.ChainResponseAggregator
+SSEEventType = response_aggregator.SSEEventType
+send_sse_event = response_aggregator.send_sse_event
+
+
+@pytest.mark.asyncio
+async def test_chain_response_aggregator():
+    agg = ChainResponseAggregator("chain", 2)
+    await agg.add_agent_response("a1", "one")
+    assert not await agg.should_send_response()
+    await agg.add_agent_response("a2", "two")
+    assert await agg.should_send_response()
+    result = await agg.get_aggregated_response()
+    assert result["chain"] == "chain"
+    assert result["responses"] == {"a1": "one", "a2": "two"}
+
+
+class _DummyStream:
+    def __init__(self) -> None:
+        self.sent = []
+
+    async def send(self, data):
+        self.sent.append(data)
+
+
+@pytest.mark.asyncio
+async def test_send_sse_event():
+    stream = _DummyStream()
+    await send_sse_event(SSEEventType.AGENT_START, {"foo": "bar"}, stream)
+    assert stream.sent == [{"event": "agent_start", "data": {"foo": "bar"}}]


### PR DESCRIPTION
This pull request introduces a new `ChainResponseAggregator` class to manage and aggregate responses from multi-agent workflows, integrates it into the `ChainAgent` execution flow, and adds unit tests to validate its functionality. These changes enhance the system's ability to handle complex workflows involving multiple agents and improve response aggregation.

### New feature: `ChainResponseAggregator` for response aggregation
* Added the `ChainResponseAggregator` class in `src/mcp_agent/server/response_aggregator.py` to manage responses from multi-agent workflows. It tracks agent responses, determines when to send aggregated responses, and provides the aggregated result.
* Introduced the `SSEEventType` enum and `send_sse_event` function in the same file to facilitate communication using server-sent events.

### Integration with `ChainAgent`
* Updated `src/mcp_agent/agents/workflow/chain_agent.py` to incorporate the `ChainResponseAggregator` into the `generate` method. Responses from each agent in the chain are now recorded, and aggregated responses can be sent when all agents have completed their tasks. [[1]](diffhunk://#diff-fc234aaccf8afe4502621ad539b43d2056bf530f7c9ead948236beb9b1ca8f8bR74-R88) [[2]](diffhunk://#diff-fc234aaccf8afe4502621ad539b43d2056bf530f7c9ead948236beb9b1ca8f8bR108-R109) [[3]](diffhunk://#diff-fc234aaccf8afe4502621ad539b43d2056bf530f7c9ead948236beb9b1ca8f8bL114-R134)

### Server-side support for response aggregation
* Modified `src/mcp_agent/mcp_server/agent_server.py` to initialize and manage the `ChainResponseAggregator` when executing multi-agent workflows. This includes passing the aggregator through the context and cleaning it up after execution. [[1]](diffhunk://#diff-86d2766d4bbe9e24cf64d21cd994931b465ba72ff8e651bb560d8849bf26fd49R19) [[2]](diffhunk://#diff-86d2766d4bbe9e24cf64d21cd994931b465ba72ff8e651bb560d8849bf26fd49L80-R95) [[3]](diffhunk://#diff-86d2766d4bbe9e24cf64d21cd994931b465ba72ff8e651bb560d8849bf26fd49L371-R394) [[4]](diffhunk://#diff-86d2766d4bbe9e24cf64d21cd994931b465ba72ff8e651bb560d8849bf26fd49R423-R425) [[5]](diffhunk://#diff-86d2766d4bbe9e24cf64d21cd994931b465ba72ff8e651bb560d8849bf26fd49R437-R438)

### Unit tests for `ChainResponseAggregator`
* Added unit tests in `tests/unit/mcp_agent/server/test_response_aggregator.py` to validate the functionality of the `ChainResponseAggregator` class and the `send_sse_event` function. The tests ensure correct response aggregation and event sending behavior.